### PR TITLE
Add geda-pcb matching 

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,7 @@ We should be able to identify files output by the following programs:
 * Eagle
 * Altium
 * Orcad
+* gEDA PCB
 
 ## contributing
 

--- a/index.js
+++ b/index.js
@@ -21,49 +21,49 @@ var layerTypes = [
     name: {
       en: 'top copper'
     },
-    match: /(F_Cu)|(\.((cmp)|(top)|(gtl)))/i
+    match: /((F_Cu)|(top\.))|(\.((cmp)|(top$)|(gtl)))/i
   },
   {
     id: 'tsm',
     name: {
       en: 'top soldermask'
     },
-    match: /(F_Mask)|(\.((stc)|(tsm)|(gts)|(smt)))/i
+    match: /((F_Mask)|(topmask))|(\.((stc)|(tsm)|(gts)|(smt)))/i
   },
   {
     id: 'tss',
     name: {
       en: 'top silkscreen'
     },
-    match: /(F_SilkS)|(\.((plc)|(tsk)|(gto)|(sst)))/i
+    match: /((F_SilkS)|(topsilk))|(\.((plc)|(tsk)|(gto)|(sst)))/i
   },
   {
     id: 'tsp',
     name: {
       en: 'top solderpaste'
     },
-    match: /(F_Paste)|(\.((crc)|(tsp)|(gtp)|(spt)))/i
+    match: /((F_Paste)|(toppaste))|(\.((crc)|(tsp)|(gtp)|(spt)))/i
   },
   {
     id: 'bcu',
     name: {
       en: 'bottom copper'
     },
-    match: /(B_Cu)|(\.((sol)|(bot)|(gbl)))/i
+    match: /(B_Cu|bottom\.)|(\.((sol)|(bot$)|(gbl)))/i
   },
   {
     id: 'bsm',
     name: {
       en: 'bottom soldermask'
     },
-    match: /(B_Mask)|(\.((sts)|(bsm)|(gbs)|(smb)))/i
+    match: /(B_Mask|bottommask\.)|(\.((sts)|(bsm)|(gbs)|(smb)))/i
   },
   {
     id: 'bss',
     name: {
       en: 'bottom silkscreen'
     },
-    match: /(B_SilkS)|(\.((pls)|(bsk)|(gbo)|(ssb)))/i
+    match: /((B_SilkS)|(bottomsilk\.))|(\.((pls)|(bsk)|(gbo)|(ssb)))/i
   },
   {
     id: 'bsp',
@@ -84,14 +84,14 @@ var layerTypes = [
     name: {
       en: 'board outline'
     },
-    match: /(Edge_Cuts)|(\.((dim)|(mil)|(gm[l\d])|(gko)|(fab)))/i
+    match: /((Edge_Cuts)|(outline))|(\.((dim)|(mil)|(gm[l\d])|(gko)|(fab$)))/i
   },
   {
     id: 'drl',
     name: {
       en: 'drill hits'
     },
-    match: /\.((drl)|(xln)|(txt)|(tap)|(drd))/i
+    match: /\.((fab\.gbr)|(cnc)|(drl)|(xln)|(txt)|(tap)|(drd))/i
   },
   {
     id: 'drw',

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "whats-that-gerber",
-  "version": "2.0.1",
+  "version": "2.0.2",
   "description": "Guesses the PCB layer type given a filename of a Gerber or drill file",
   "main": "index.js",
   "scripts": {

--- a/test/filenames-by-cad.js
+++ b/test/filenames-by-cad.js
@@ -70,7 +70,7 @@ module.exports = [
     ]
   },
   {
-    cad: 'alitum',
+    cad: 'altium',
     files: [
       // top copper
       {name: 'board.gtl', type: 'tcu'},

--- a/test/filenames-by-cad.js
+++ b/test/filenames-by-cad.js
@@ -123,5 +123,20 @@ module.exports = [
       // drill
       {name: 'board.TAP', type: 'drl'}
     ]
+  },
+  {
+    cad: 'geda-pcb',
+    files: [
+      {name: 'board.bottom.gbr',       type: 'bcu'},
+      {name: 'board.bottommask.gbr',   type: 'bsm'},
+      {name: 'board.bottomsilk.gbr',   type: 'bss'},
+      {name: 'board.fab.gbr',          type: 'drl'},
+      {name: 'board.plated-drill.cnc', type: 'drl'},
+      {name: 'board.outline.gbr',      type: 'out'},
+      {name: 'board.top.gbr',          type: 'tcu'},
+      {name: 'board.topmask.gbr',      type: 'tsm'},
+      {name: 'board.toppaste.gbr',     type: 'tsp'},
+      {name: 'board.topsilk.gbr',      type: 'tss'}
+    ]
   }
 ]


### PR DESCRIPTION
These match the default outputs from PCB version 20110918 (from Ubuntu 14.04 repository)
with `pcb -x gerber`.