### PR TITLE
Add matching for new KiCad convention

### DIFF
--- a/index.js
+++ b/index.js
@@ -21,70 +21,70 @@ var layerTypes = [
     name: {
       en: 'top copper'
     },
-    match: /((F_Cu)|(top\.))|(\.((cmp)|(top$)|(gtl)))/i
+    match: /((F.Cu)|(top\.))|(\.((cmp)|(top$)|(gtl)))/i
   },
   {
     id: 'tsm',
     name: {
       en: 'top soldermask'
     },
-    match: /((F_Mask)|(topmask))|(\.((stc)|(tsm)|(gts)|(smt)))/i
+    match: /((F.Mask)|(topmask))|(\.((stc)|(tsm)|(gts)|(smt)))/i
   },
   {
     id: 'tss',
     name: {
       en: 'top silkscreen'
     },
-    match: /((F_SilkS)|(topsilk))|(\.((plc)|(tsk)|(gto)|(sst)))/i
+    match: /((F.SilkS)|(topsilk))|(\.((plc)|(tsk)|(gto)|(sst)))/i
   },
   {
     id: 'tsp',
     name: {
       en: 'top solderpaste'
     },
-    match: /((F_Paste)|(toppaste))|(\.((crc)|(tsp)|(gtp)|(spt)))/i
+    match: /((F.Paste)|(toppaste))|(\.((crc)|(tsp)|(gtp)|(spt)))/i
   },
   {
     id: 'bcu',
     name: {
       en: 'bottom copper'
     },
-    match: /(B_Cu|bottom\.)|(\.((sol)|(bot$)|(gbl)))/i
+    match: /(B.Cu|bottom\.)|(\.((sol)|(bot$)|(gbl)))/i
   },
   {
     id: 'bsm',
     name: {
       en: 'bottom soldermask'
     },
-    match: /(B_Mask|bottommask\.)|(\.((sts)|(bsm)|(gbs)|(smb)))/i
+    match: /(B.Mask|bottommask\.)|(\.((sts)|(bsm)|(gbs)|(smb)))/i
   },
   {
     id: 'bss',
     name: {
       en: 'bottom silkscreen'
     },
-    match: /((B_SilkS)|(bottomsilk\.))|(\.((pls)|(bsk)|(gbo)|(ssb)))/i
+    match: /((B.SilkS)|(bottomsilk\.))|(\.((pls)|(bsk)|(gbo)|(ssb)))/i
   },
   {
     id: 'bsp',
     name: {
       en: 'bottom solderpaste'
     },
-    match: /(B_Paste)|(\.((crs)|(bsp)|(gbp)|(spb)))/i
+    match: /(B.Paste)|(\.((crs)|(bsp)|(gbp)|(spb)))/i
   },
   {
     id: 'icu',
     name: {
       en: 'inner copper'
     },
-    match: /(In\d+_Cu)|(\.((ly)|(g)|(in))\d+)/i
+    match: /(In\d+.Cu)|(\.((ly)|(g)|(in))\d+)/i
   },
   {
     id: 'out',
     name: {
       en: 'board outline'
     },
-    match: /((Edge_Cuts)|(outline))|(\.((dim)|(mil)|(gm[l\d])|(gko)|(fab$)))/i
+    match: /((Edge.Cuts)|(outline))|(\.((dim)|(mil)|(gm[l\d])|(gko)|(fab$)))/i
   },
   {
     id: 'drl',

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "whats-that-gerber",
-  "version": "2.0.2",
+  "version": "2.0.1",
   "description": "Guesses the PCB layer type given a filename of a Gerber or drill file",
   "main": "index.js",
   "scripts": {

--- a/test/filenames-by-cad.js
+++ b/test/filenames-by-cad.js
@@ -7,24 +7,34 @@ module.exports = [
     files: [
       // top copper
       {name: 'board-F_Cu.gbr', type: 'tcu'},
+      {name: 'board-F.Cu.gbr', type: 'tcu'},
       // top soldermask
       {name: 'board-F_Mask.gbr', type: 'tsm'},
+      {name: 'board-F.Mask.gbr', type: 'tsm'},
       // top silkscreen
       {name: 'board-F_SilkS.gbr', type: 'tss'},
+      {name: 'board-F.SilkS.gbr', type: 'tss'},
       // top solderpaste
       {name: 'board-F_Paste.gbr', type: 'tsp'},
+      {name: 'board-F.Paste.gbr', type: 'tsp'},
       // bottom copper
       {name: 'board-B_Cu.gbr', type: 'bcu'},
+      {name: 'board-B.Cu.gbr', type: 'bcu'},
       // bottom soldermask
       {name: 'board-B_Mask.gbr', type: 'bsm'},
+      {name: 'board-B.Mask.gbr', type: 'bsm'},
       // bottom silkscreen
       {name: 'board-B_SilkS.gbr', type: 'bss'},
+      {name: 'board-B.SilkS.gbr', type: 'bss'},
       // bottom paste
       {name: 'board-B_Paste.gbr', type: 'bsp'},
+      {name: 'board-B.Paste.gbr', type: 'bsp'},
       // inner copper
       {name: 'board-In1_Cu.gbr', type: 'icu'},
+      {name: 'board-In1.Cu.gbr', type: 'icu'},
       // outline
       {name: 'board-Edge_Cuts.gbr', type: 'out'},
+      {name: 'board-Edge.Cuts.gbr', type: 'out'},
       // drill
       {name: 'board.drl', type: 'drl'}
     ]


### PR DESCRIPTION
KiCad is switching from the `_` to a `.` , e.g. `Edge_Cuts` is now `Edge.Cuts`. This branch is based on the branch in #3 as merging will be easier, can rebase on tracespace:master when that one is amended/rejected/merged.  