### PR TITLE
Add isValidType method to check for valid types (fixes #11)

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,21 @@ icu  | inner copper
 out  | board outline      
 drl  | drill hits         
 
+#### checking if a layer type is valid
+
+You can check if any given string is a valid layer type with:
+
+``` js
+var whatsThatGerber = require('whats-that-gerber')
+var isValidType = whatsThatGerber.isValidType
+
+var type1 = 'tsm'
+var type2 = 'hello'
+
+console.log(isValidType(type1)) // true
+console.log(isValidType(type2)) // false
+```
+
 ### full name locales
 
 The full name method takes a locale string as its second parameter, which defaults to 'en':

--- a/index.js
+++ b/index.js
@@ -114,6 +114,12 @@ module.exports.getAllTypes = function() {
   })
 }
 
+module.exports.isValidType = function(type) {
+  return layerTypes.some(function(layerType) {
+    return layerType.id === type
+  })
+}
+
 module.exports.getFullName = function whatsThatGerberTypeName(typeId, locale) {
   var type = find(layerTypes, function(type) {
     return type.id === typeId

--- a/test/index.js
+++ b/test/index.js
@@ -46,6 +46,22 @@ describe('whats-that-gerber', function() {
       'drl')
   })
 
+  it('should know which types are valid', function() {
+    var allTypes = whatsThatGerber.getAllTypes()
+
+    allTypes.forEach(function(type) {
+      expect(whatsThatGerber.isValidType(type)).to.be.true
+    })
+  })
+
+  it('should know which types are invalid', function() {
+    var invalidTypes = ['foo', 'bar', 'baz', 'quux']
+
+    invalidTypes.forEach(function(type) {
+      expect(whatsThatGerber.isValidType(type)).to.be.false
+    })
+  })
+
   it('should have full names for all layer types', function() {
     whatsThatGerber.getAllTypes().forEach(function(type) {
       expect(whatsThatGerber.getFullName(type)).to.equal(typeNames[type])


### PR DESCRIPTION
Usage:

``` js
var whatsThatGerber = require('whats-that-gerber')
var isValidType = whatsThatGerber.isValidType

var type1 = 'tsm'
var type2 = 'hello'

console.log(isValidType(type1)) // true
console.log(isValidType(type2)) // false
```