### PR TITLE
Add support for some Proteus layer names

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,6 +76,7 @@ We should be able to identify files output by the following programs:
 * Altium
 * Orcad
 * gEDA PCB
+* Proteus
 
 ## contributing
 

--- a/index.js
+++ b/index.js
@@ -21,21 +21,21 @@ var layerTypes = [
     name: {
       en: 'top copper'
     },
-    match: /((F.Cu)|(top\.gbr$))|(\.((cmp$)|(top$)|(gtl$)))|(\.toplayer\.ger$)/i
+    match: /((F.Cu)|(top\.gbr$))|(\.((cmp$)|(top$)|(gtl$)))|(\.toplayer\.ger$)|(top copper\.txt$)/i
   },
   {
     id: 'tsm',
     name: {
       en: 'top soldermask'
     },
-    match: /((F.Mask)|(topmask))|(\.((stc$)|(tsm$)|(gts$)|(smt$)))|(\.topsoldermask\.ger$)/i
+    match: /((F.Mask)|(topmask))|(\.((stc$)|(tsm$)|(gts$)|(smt$)))|(\.topsoldermask\.ger$)|(top solder resist\.txt$)/i
   },
   {
     id: 'tss',
     name: {
       en: 'top silkscreen'
     },
-    match: /((F.SilkS)|(topsilk))|(\.((plc$)|(tsk$)|(gto$)|(sst$)))|(\.topsilkscreen\.ger$)/i
+    match: /((F.SilkS)|(topsilk))|(\.((plc$)|(tsk$)|(gto$)|(sst$)))|(\.topsilkscreen\.ger$)|(top silk screen\.txt$)/i
   },
   {
     id: 'tsp',
@@ -49,21 +49,21 @@ var layerTypes = [
     name: {
       en: 'bottom copper'
     },
-    match: /(B.Cu|bottom\.gbr$)|(\.((sol$)|(bot$)|(gbl$)))|(\.bottomlayer\.ger$)/i
+    match: /(B.Cu|bottom\.gbr$)|(\.((sol$)|(bot$)|(gbl$)))|(\.bottomlayer\.ger$)|(bottom copper\.txt$)/i
   },
   {
     id: 'bsm',
     name: {
       en: 'bottom soldermask'
     },
-    match: /(B.Mask|bottommask\.)|(\.((sts$)|(bsm$)|(gbs$)|(smb$)))|(\.bottomsoldermask\.ger$)/i
+    match: /(B.Mask|bottommask\.)|(\.((sts$)|(bsm$)|(gbs$)|(smb$)))|(\.bottomsoldermask\.ger$)|(bottom solder resist\.txt$)/i
   },
   {
     id: 'bss',
     name: {
       en: 'bottom silkscreen'
     },
-    match: /((B.SilkS)|(bottomsilk\.))|(\.((pls$)|(bsk$)|(gbo$)|(ssb$)))|(\.bottomsilkscreen\.ger$)/i
+    match: /((B.SilkS)|(bottomsilk\.))|(\.((pls$)|(bsk$)|(gbo$)|(ssb$)))|(\.bottomsilkscreen\.ger$)|(bottom silk screen\.txt$)/i
   },
   {
     id: 'bsp',
@@ -84,7 +84,7 @@ var layerTypes = [
     name: {
       en: 'board outline'
     },
-    match: /(Edge.Cuts)|(\.((dim$)|(mil$)|(gm[l\d]$)|(gko$)|(fab$)))|(\.boardoutline\.ger$)|(\.outline\.gbr$)/i
+    match: /(Edge.Cuts)|(\.((dim$)|(mil$)|(gm[l\d]$)|(gko$)|(fab$)))|(\.boardoutline\.ger$)|(\.outline\.gbr$)|(mechanical \d+\.txt$)/i
   },
   {
     id: 'drl',

--- a/test/filenames-by-cad.json
+++ b/test/filenames-by-cad.json
@@ -131,5 +131,18 @@
       {"name": "board-name.topsoldermask.ger",    "type": "tsm"},
       {"name": "board-name.tcream.ger",           "type": "tsp"}
     ]
+  },
+  {
+    "cad": "proteus",
+    "files": [
+      {"name": "board-name CADCAM Bottom Copper.TXT",        "type": "bcu"},
+      {"name": "board-name CADCAM Bottom Silk Screen.TXT",   "type": "bss"},
+      {"name": "board-name CADCAM Bottom Solder Resist.TXT", "type": "bsm"},
+      {"name": "board-name CADCAM Drill.TXT",                "type": "drl"},
+      {"name": "board-name CADCAM Mechanical 1.TXT",         "type": "out"},
+      {"name": "board-name CADCAM Top Copper.TXT",           "type": "tcu"},
+      {"name": "board-name CADCAM Top Silk Screen.TXT",      "type": "tss"},
+      {"name": "board-name CADCAM Top Solder Resist.TXT",    "type": "tsm"}
+    ]
   }
 ]


### PR DESCRIPTION
Found at https://github.com/rwb27/openflexure_nano_motor_controller/tree/0542999eae64a6b8251138111958430aa304e5a9/pcb_design/gerber/normal